### PR TITLE
Add support for `pull_request_target` to support public forks

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -9,7 +9,7 @@ async function action() {
         const debugMode = (core.getInput('debug-mode') === 'true');
 
         const event = github.context.eventName;
-        if (event != 'pull_request') {
+        if (event.includes('pull_request')) {
             throw `Only pull request is supported, ${github.context.eventName} not supported.`;
         }
 


### PR DESCRIPTION
This is need to have the correct permission and secrets. It's the recomanadation from the GitHub.

https://github.com/Madrapps/add-reviewers/issues/1#issuecomment-1049228652